### PR TITLE
surface bindings to clients of the api

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           - '1.19'
           - '1.20'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up Go
@@ -40,7 +40,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: golangci-lint

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -12,7 +12,7 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up Go

--- a/jp.go
+++ b/jp.go
@@ -14,6 +14,7 @@ var (
 	Compile     = api.Compile
 	MustCompile = api.MustCompile
 	Search      = api.Search
+	SearchWithParams = api.SearchWithParams
 )
 
 // parsing types

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -48,6 +48,19 @@ func jpfEcho(arguments []interface{}) (interface{}, error) {
 	return arguments[0], nil
 }
 
+func TestSearchWithParams(t *testing.T) {
+
+	expression := "let $answer = $number in $answer"
+	params := map[string]interface{}{ "number": 42.0 }
+	want := 42.0
+
+	assert := assert.New(t)
+	got, err := SearchWithParams(expression, nil, params)
+
+	assert.Nil(err)
+	assert.Equal(want, got)
+}
+
 func TestSearch(t *testing.T) {
 	type args struct {
 		expression string


### PR DESCRIPTION
To review the pull request I have toyed with the `jp` command-line utility and added a `--params` command-line switch as suggested by James in the `let-expression` spec.

This lead me to produce the following code that you may want to take inspiration from.
